### PR TITLE
Change UAC level from administratior to asInvoker

### DIFF
--- a/Metro WPF Template/Properties/app.manifest
+++ b/Metro WPF Template/Properties/app.manifest
@@ -8,7 +8,7 @@
             If you want to change the Windows User Account Control level replace the 
             requestedExecutionLevel node with one of the following. -->
 
-        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
 
         <!-- Specifying requestedExecutionLevel node will disable file and registry virtualization.
             If you want to utilize File and Registry Virtualization for backward 


### PR DESCRIPTION
XboxChaos/Assembly understandably requires admin permissions to run, but MetroWPFTemplate has no default need of this.
